### PR TITLE
fixes token workflow for the frontend

### DIFF
--- a/src/graphql/resolvers/mutations/application.js
+++ b/src/graphql/resolvers/mutations/application.js
@@ -5,12 +5,9 @@ import applicationService from '../../../services/application';
 
 const updateApplication = async (root, args, context) => {
   try {
-    const { id, level } = context;
+    const { id } = context;
     if (!id) {
       throw new ForbiddenError('User is not logged in.');
-    }
-    if (level !== 'HACKER') {
-      throw new ForbiddenError('User is not a HACKER.');
     }
     const application = await applicationService.updateApplication(id, args);
     return application;
@@ -21,12 +18,9 @@ const updateApplication = async (root, args, context) => {
 
 const submitApplication = async (root, args, context) => {
   try {
-    const { id, level } = context;
+    const { id } = context;
     if (!id) {
       throw new ForbiddenError('User is not logged in.');
-    }
-    if (level !== 'HACKER') {
-      throw new ForbiddenError('User is not a HACKER.');
     }
     const application = await applicationService.updateApplication(id, args);
     await userService.updateStatus(id, 'SUBMITTED');

--- a/src/graphql/resolvers/mutations/user.js
+++ b/src/graphql/resolvers/mutations/user.js
@@ -28,9 +28,12 @@ const signUp = async (root, args) => {
       },
       { include: [Application] },
     );
-    const token = jwt.sign({ id, verification: true }, SECRET);
-    await emailService.sendVerification(email, token);
-    return email;
+
+    const verificationToken = jwt.sign({ id, verification: true }, SECRET);
+    await emailService.sendVerification(email, verificationToken);
+
+    const loginToken = jwt.sign({ id });
+    return { token: loginToken };
   } catch (err) {
     throw err;
   }
@@ -44,12 +47,12 @@ const logIn = async (root, args) => {
     if (!user || !correctPassword) {
       throw new AuthenticationError('Incorrect login');
     }
-    const { id, level, status } = user;
+    const { id, status } = user;
     if (status === 'UNVERIFIED') {
       throw new ForbiddenError('User unverified');
     }
-    const token = jwt.sign({ id, level }, SECRET);
-    return { token };
+    const loginToken = jwt.sign({ id }, SECRET);
+    return { token: loginToken };
   } catch (err) {
     throw err;
   }
@@ -62,9 +65,8 @@ const verify = async (root, args) => {
     if (!verification) {
       throw new AuthenticationError('Invalid token.');
     }
-    const user = await userService.updateStatus(id, 'VERIFIED');
-    const { level } = user;
-    const loginToken = jwt.sign({ id, level }, SECRET);
+    await userService.updateStatus(id, 'VERIFIED');
+    const loginToken = jwt.sign({ id }, SECRET);
     return { token: loginToken };
   } catch (err) {
     throw err;

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -33,7 +33,7 @@ type Token {
 }
 
 type Mutation {
-  signUp(email: String!, password: String!): String!
+  signUp(email: String!, password: String!): Token!
   logIn(email: String!, password: String!): Token!
   verify(token: String!): Token!
   updateApplication(

--- a/src/services/application.js
+++ b/src/services/application.js
@@ -4,7 +4,10 @@ import { Application, User } from '../models';
 
 const updateApplication = async (userId, args) => {
   try {
-    const { status } = await User.findByPk(userId);
+    const { status, level } = await User.findByPk(userId);
+    if (level !== 'HACKER') {
+      throw new ForbiddenError('User is not a HACKER.');
+    }
     if (status !== 'VERIFIED') {
       throw new ForbiddenError('User has already submitted an application.');
     }


### PR DESCRIPTION
We don't actually need level in the frontend, since we actually need to make a database query every single time we would need to check the level of the token.

This adjusts for that change and also gives the frontend a login token from the signup, not much that a user can do with it since we're checking for a verification field anyway.