### PR TITLE
Convert SQL with Sequelize to Mongodb with Mongoose

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "express-jwt": "^5.3.1",
     "graphql": "^14.0.2",
     "jsonwebtoken": "^8.3.0",
+    "mongoose": "^5.3.13",
     "pg": "^7.6.0",
     "sequelize": "^4.41.0"
   },

--- a/package.json
+++ b/package.json
@@ -16,9 +16,7 @@
     "express-jwt": "^5.3.1",
     "graphql": "^14.0.2",
     "jsonwebtoken": "^8.3.0",
-    "mongoose": "^5.3.13",
-    "pg": "^7.6.0",
-    "sequelize": "^4.41.0"
+    "mongoose": "^5.3.13"
   },
   "scripts": {
     "deploy": "now --public && now alias",

--- a/src/database/index.js
+++ b/src/database/index.js
@@ -1,5 +1,8 @@
 import mongoose from 'mongoose';
 
+// fixing bugs from old mongo with this fix as referred to this github issue: https://github.com/Automattic/mongoose/issues/7108
+mongoose.set('useFindAndModify', false);
+
 const {
   DB_USER, DB_PASSWORD, DB_HOST, DB_NAME,
 } = process.env;
@@ -22,26 +25,3 @@ const db = () => Promise.resolve(
 db()
   .then(() => console.log('> DB Connected'))
   .catch(e => console.log(e.message));
-// import dotenv from 'dotenv';
-// import { Sequelize } from 'sequelize';
-
-// dotenv.config();
-// const {
-//   DB_NAME, DB_HOST, DB_USER, DB_PASSWORD, STAGE,
-// } = process.env;
-
-// const sequelize = new Sequelize(DB_NAME, DB_USER, DB_PASSWORD, {
-//   host: DB_HOST,
-//   dialectOptions: {
-//     ssl: STAGE === 'PROD',
-//   },
-//   dialect: 'postgres',
-//   operatorsAliases: false,
-// });
-
-// sequelize
-//   .authenticate()
-//   .then(console.log('Connection has been established successfully.'))
-//   .catch(err => console.error('Unable to connect to the database:', err));
-
-// export { sequelize, Sequelize };

--- a/src/database/index.js
+++ b/src/database/index.js
@@ -1,23 +1,47 @@
-import dotenv from 'dotenv';
-import { Sequelize } from 'sequelize';
+import mongoose from 'mongoose';
 
-dotenv.config();
 const {
-  DB_NAME, DB_HOST, DB_USER, DB_PASSWORD, STAGE,
+  DB_USER, DB_PASSWORD, DB_HOST, DB_NAME,
 } = process.env;
 
-const sequelize = new Sequelize(DB_NAME, DB_USER, DB_PASSWORD, {
-  host: DB_HOST,
-  dialectOptions: {
-    ssl: STAGE === 'PROD',
-  },
-  dialect: 'postgres',
-  operatorsAliases: false,
-});
+const options = {
+  user: DB_USER,
+  pass: DB_PASSWORD,
+  useNewUrlParser: true,
+  useCreateIndex: true,
+};
 
-sequelize
-  .authenticate()
-  .then(console.log('Connection has been established successfully.'))
-  .catch(err => console.error('Unable to connect to the database:', err));
+const db = () => Promise.resolve(
+  mongoose.connect(
+    `${DB_HOST}/${DB_NAME}`,
+    options,
+  ),
+);
 
-export { sequelize, Sequelize };
+
+db()
+  .then(() => console.log('> DB Connected'))
+  .catch(e => console.log(e.message));
+// import dotenv from 'dotenv';
+// import { Sequelize } from 'sequelize';
+
+// dotenv.config();
+// const {
+//   DB_NAME, DB_HOST, DB_USER, DB_PASSWORD, STAGE,
+// } = process.env;
+
+// const sequelize = new Sequelize(DB_NAME, DB_USER, DB_PASSWORD, {
+//   host: DB_HOST,
+//   dialectOptions: {
+//     ssl: STAGE === 'PROD',
+//   },
+//   dialect: 'postgres',
+//   operatorsAliases: false,
+// });
+
+// sequelize
+//   .authenticate()
+//   .then(console.log('Connection has been established successfully.'))
+//   .catch(err => console.error('Unable to connect to the database:', err));
+
+// export { sequelize, Sequelize };

--- a/src/env.js
+++ b/src/env.js
@@ -1,0 +1,3 @@
+import dotenv from 'dotenv';
+
+dotenv.config();

--- a/src/graphql/resolvers/mutations/application.js
+++ b/src/graphql/resolvers/mutations/application.js
@@ -14,7 +14,7 @@ const updateApplication = async (root, args, context) => {
 const submitApplication = async (root, args, context) => {
   try {
     const { id } = context;
-    const application = await applicationService.updateApplication(id, args);
+    const application = await applicationService.update(id, args);
     await userService.updateStatus(id, 'SUBMITTED');
     return application;
   } catch (err) {

--- a/src/graphql/resolvers/queries/user.js
+++ b/src/graphql/resolvers/queries/user.js
@@ -1,5 +1,5 @@
 import { AuthenticationError } from 'apollo-server-express';
-import { User } from '../../../models';
+import User from '../../../models';
 
 const user = async (root, args, context) => {
   try {

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,6 @@ import typeDefs from './graphql/schema.gql';
 import resolvers from './graphql/resolvers';
 import './database';
 
-// import { initSequelize } from './models';
 const { PORT, SECRET, SERVER_URL } = process.env;
 
 const app = express();
@@ -30,7 +29,5 @@ const server = new ApolloServer({
 app.use(jwt({ secret: SECRET, credentialsRequired: false }));
 
 server.applyMiddleware({ app });
-
-// initSequelize();
 
 app.listen({ port: PORT }, () => console.log(`🍑  Server up on ${SERVER_URL}:${PORT}${server.graphqlPath}`));

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,14 @@
+import './env';
+
 import express from 'express';
 import jwt from 'express-jwt';
 import { ApolloServer } from 'apollo-server-express';
 
 import typeDefs from './graphql/schema.gql';
 import resolvers from './graphql/resolvers';
+import './database';
 
-import { initSequelize } from './models';
-
+// import { initSequelize } from './models';
 const { PORT, SECRET, SERVER_URL } = process.env;
 
 const app = express();
@@ -29,6 +31,6 @@ app.use(jwt({ secret: SECRET, credentialsRequired: false }));
 
 server.applyMiddleware({ app });
 
-initSequelize();
+// initSequelize();
 
 app.listen({ port: PORT }, () => console.log(`🍑  Server up on ${SERVER_URL}:${PORT}${server.graphqlPath}`));

--- a/src/models/application.js
+++ b/src/models/application.js
@@ -8,13 +8,3 @@ const ApplicationDocument = Mongoose => new Mongoose.Schema({
 });
 
 export default ApplicationDocument;
-// const ApplicationModel = (sequelize, Sequelize) => sequelize.define('application', {
-//   firstName: { type: Sequelize.STRING },
-//   lastName: { type: Sequelize.STRING },
-//   levelOfStudy: { type: Sequelize.STRING },
-//   major: { type: Sequelize.STRING },
-//   shirtSize: { type: Sequelize.STRING },
-//   gender: { type: Sequelize.STRING },
-// });
-
-// export default ApplicationModel;

--- a/src/models/application.js
+++ b/src/models/application.js
@@ -1,4 +1,4 @@
-const ApplicationDocument = Mongoose => new Mongoose.Schema({
+const ApplicationSchema = Mongoose => new Mongoose.Schema({
   firstName: String,
   lastName: String,
   levelOfStudy: String,
@@ -7,4 +7,4 @@ const ApplicationDocument = Mongoose => new Mongoose.Schema({
   gender: String,
 });
 
-export default ApplicationDocument;
+export default ApplicationSchema;

--- a/src/models/application.js
+++ b/src/models/application.js
@@ -1,10 +1,20 @@
-const ApplicationModel = (sequelize, Sequelize) => sequelize.define('application', {
-  firstName: { type: Sequelize.STRING },
-  lastName: { type: Sequelize.STRING },
-  levelOfStudy: { type: Sequelize.STRING },
-  major: { type: Sequelize.STRING },
-  shirtSize: { type: Sequelize.STRING },
-  gender: { type: Sequelize.STRING },
+const ApplicationDocument = Mongoose => new Mongoose.Schema({
+  firstName: String,
+  lastName: String,
+  levelOfStudy: String,
+  major: String,
+  shirtSize: String,
+  gender: String,
 });
 
-export default ApplicationModel;
+export default ApplicationDocument;
+// const ApplicationModel = (sequelize, Sequelize) => sequelize.define('application', {
+//   firstName: { type: Sequelize.STRING },
+//   lastName: { type: Sequelize.STRING },
+//   levelOfStudy: { type: Sequelize.STRING },
+//   major: { type: Sequelize.STRING },
+//   shirtSize: { type: Sequelize.STRING },
+//   gender: { type: Sequelize.STRING },
+// });
+
+// export default ApplicationModel;

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,23 +1,8 @@
 import mongoose from 'mongoose';
-import ApplicationDocument from './application';
+import ApplicationSchema from './application';
 import UserDocument from './user';
 
-const Application = ApplicationDocument(mongoose);
+const Application = ApplicationSchema(mongoose);
 const User = UserDocument(mongoose, Application);
 
 export default User;
-
-// import { sequelize, Sequelize } from '../database';
-
-// import ApplicationModel from './application';
-// import UserModel from './user';
-
-// const Application = ApplicationModel(sequelize, Sequelize);
-// const User = UserModel(sequelize, Sequelize);
-
-// const initSequelize = () => {
-//   User.hasOne(Application, { foreignKey: { allowNull: true }, onDelete: 'CASCADE' });
-//   sequelize.sync();
-// };
-
-// export { Application, User, initSequelize };

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,14 +1,23 @@
-import { sequelize, Sequelize } from '../database';
+import mongoose from 'mongoose';
+import ApplicationDocument from './application';
+import UserDocument from './user';
 
-import ApplicationModel from './application';
-import UserModel from './user';
+const Application = ApplicationDocument(mongoose);
+const User = UserDocument(mongoose, Application);
 
-const Application = ApplicationModel(sequelize, Sequelize);
-const User = UserModel(sequelize, Sequelize);
+export default User;
 
-const initSequelize = () => {
-  User.hasOne(Application, { foreignKey: { allowNull: true }, onDelete: 'CASCADE' });
-  sequelize.sync();
-};
+// import { sequelize, Sequelize } from '../database';
 
-export { Application, User, initSequelize };
+// import ApplicationModel from './application';
+// import UserModel from './user';
+
+// const Application = ApplicationModel(sequelize, Sequelize);
+// const User = UserModel(sequelize, Sequelize);
+
+// const initSequelize = () => {
+//   User.hasOne(Application, { foreignKey: { allowNull: true }, onDelete: 'CASCADE' });
+//   sequelize.sync();
+// };
+
+// export { Application, User, initSequelize };

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,8 +1,8 @@
 import mongoose from 'mongoose';
 import ApplicationSchema from './application';
-import UserDocument from './user';
+import UserSchema from './user';
 
 const Application = ApplicationSchema(mongoose);
-const User = UserDocument(mongoose, Application);
+const User = UserSchema(mongoose, Application);
 
 export default User;

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -1,8 +1,17 @@
-const UserModel = (sequelize, Sequelize) => sequelize.define('user', {
-  email: { type: Sequelize.STRING, unique: true, allowNull: false },
-  password: { type: Sequelize.STRING, allowNull: false },
-  level: { type: Sequelize.STRING, allowNull: false },
-  status: { type: Sequelize.STRING, allowNull: false },
-});
+const UserDocument = (Mongoose, application) => Mongoose.model('users', new Mongoose.Schema({
+  email: { type: String, required: true, unique: true },
+  password: { type: String, required: true },
+  level: { type: String, required: true },
+  status: { type: String, required: true },
+  application,
+}));
 
-export default UserModel;
+export default UserDocument;
+// const UserModel = (sequelize, Sequelize) => sequelize.define('user', {
+//   email: { type: Sequelize.STRING, unique: true, allowNull: false },
+//   password: { type: Sequelize.STRING, allowNull: false },
+//   level: { type: Sequelize.STRING, allowNull: false },
+//   status: { type: Sequelize.STRING, allowNull: false },
+// });
+
+// export default UserModel;

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -1,4 +1,4 @@
-const UserDocument = (Mongoose, application) => Mongoose.model('users', new Mongoose.Schema({
+const UserSchema = (Mongoose, application) => Mongoose.model('users', new Mongoose.Schema({
   email: { type: String, required: true, unique: true },
   password: { type: String, required: true },
   level: { type: String, required: true },
@@ -6,4 +6,4 @@ const UserDocument = (Mongoose, application) => Mongoose.model('users', new Mong
   application,
 }));
 
-export default UserDocument;
+export default UserSchema;

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -7,11 +7,3 @@ const UserDocument = (Mongoose, application) => Mongoose.model('users', new Mong
 }));
 
 export default UserDocument;
-// const UserModel = (sequelize, Sequelize) => sequelize.define('user', {
-//   email: { type: Sequelize.STRING, unique: true, allowNull: false },
-//   password: { type: Sequelize.STRING, allowNull: false },
-//   level: { type: Sequelize.STRING, allowNull: false },
-//   status: { type: Sequelize.STRING, allowNull: false },
-// });
-
-// export default UserModel;

--- a/src/services/application.js
+++ b/src/services/application.js
@@ -1,5 +1,5 @@
 import { ForbiddenError } from 'apollo-server-express';
-import { Application, User } from '../models';
+import User from '../models';
 
 /**
  * Updates the given user's application with the given arguments.
@@ -11,7 +11,7 @@ const update = async (userId, args) => {
     if (!userId) {
       throw new ForbiddenError('User is not logged in.');
     }
-    const { status, level } = await User.findByPk(userId);
+    const { status, level } = await User.findById(userId);
     if (level !== 'HACKER') {
       throw new ForbiddenError('User is not a HACKER.');
     }
@@ -19,15 +19,25 @@ const update = async (userId, args) => {
       throw new ForbiddenError('User has already submitted an application.');
     }
     const {
-      firstName, lastName, levelOfStudy, major, shirtSize, gender,
+      firstName,
+      lastName,
+      levelOfStudy,
+      major,
+      shirtSize,
+      gender,
     } = args;
-    await Application.update({
-      firstName, lastName, levelOfStudy, major, shirtSize, gender,
-    },
-    {
-      where: { userId },
-    });
-    const application = Application.findOne({ where: { userId } });
+
+    const options = {
+      firstName,
+      lastName,
+      levelOfStudy,
+      major,
+      shirtSize,
+      gender,
+    };
+
+    const user = await User.findByIdAndUpdate(userId, { application: options });
+    const { application } = user;
     return application;
   } catch (err) {
     throw err;

--- a/src/services/application.js
+++ b/src/services/application.js
@@ -6,7 +6,7 @@ import User from '../models';
  * @param {number} userId The user's ID.
  * @param {Object} args The arguments with which to update the application.
  */
-const update = async (userId, args) => {
+const update = async (userId, options) => {
   try {
     if (!userId) {
       throw new ForbiddenError('User is not logged in.');
@@ -18,25 +18,8 @@ const update = async (userId, args) => {
     if (status !== 'VERIFIED') {
       throw new ForbiddenError('User has already submitted an application.');
     }
-    const {
-      firstName,
-      lastName,
-      levelOfStudy,
-      major,
-      shirtSize,
-      gender,
-    } = args;
 
-    const options = {
-      firstName,
-      lastName,
-      levelOfStudy,
-      major,
-      shirtSize,
-      gender,
-    };
-
-    const user = await User.findByIdAndUpdate(userId, { application: options });
+    const user = await User.findByIdAndUpdate(userId, { application: options }, { new: true });
     const { application } = user;
     return application;
   } catch (err) {

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -45,7 +45,6 @@ const signUp = async (email, password) => {
     );
     const { id, level } = newUser;
     const verificationToken = jwt.sign({ id, verification: true }, SECRET);
-    console.log(verificationToken);
     emailService.sendVerification(email, verificationToken);
     const loginToken = jwt.sign({ id, level }, SECRET);
     return loginToken;
@@ -63,7 +62,6 @@ const signUp = async (email, password) => {
 const logIn = async (email, password) => {
   try {
     const user = await User.findOne({ email });
-    console.log(user);
     const correctPassword = await bcrypt.compare(password, user.password);
     if (!user || !correctPassword) {
       throw new AuthenticationError('Incorrect login');


### PR DESCRIPTION
Switched Peach to using SQL, to MongoDB. This was to avoid the use of having to use sequelize migrations which could be annoying for the client as referenced in this [issue](https://github.com/hackfiu/peach/issues/19)